### PR TITLE
Fix aoSystem import

### DIFF
--- a/tiptop/tiptop.py
+++ b/tiptop/tiptop.py
@@ -1,8 +1,8 @@
 import os
 import numpy as np
 from matplotlib import rc
-from P3.aoSystem.fourierModel import *
-from P3.aoSystem.FourierUtils import *
+from aoSystem.fourierModel import *
+from aoSystem.FourierUtils import *
 from configparser import ConfigParser
 import yaml
 


### PR DESCRIPTION
Importing from `P3.aoSystem` only works when using submodules and running TIPTOP from its root directory. This is because P3 doesn't actually install a P3 package, but instead installs several directly its subpackages (`['psfFitting', 'psfr', 'psfao21', 'telemetry', 'aoSystem', 'deepLoop']`). 
This is probably something that should be fixed on P3's side, making it a real Python package. 