### PR TITLE
(GA) support for multi wavelength PSDs

### DIFF
--- a/scripts/export_psd_fixtures.py
+++ b/scripts/export_psd_fixtures.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from configparser import ConfigParser
 from pathlib import Path
 
 import numpy as np
@@ -78,6 +79,84 @@ def export_case(case_name: str, ini_dir: Path, output_dir: Path) -> Path:
     return fixture_path
 
 
+def export_multi_wavelength_case(
+    case_name: str, wavelengths_m: list[float], ini_dir: Path, output_dir: Path
+) -> Path:
+    """
+    Export a per-wavelength PSD fixture (exactMultiWavelengthPSD=True): P3
+    computes one exact PSD grid per science wavelength instead of one shared
+    grid, so unlike export_case() the resulting PSD arrays can have different
+    shapes per wavelength -- saved as separate input_psds_{i} entries plus the
+    matching per-wavelength freq_range/dk/nPixPup, rather than a single
+    input_psds array. Used by MASTSEL's per-wavelength psdSetToPsfSet
+    regression tests, kept in a separate fixture directory from export_case's
+    output so the legacy single-grid fixture-scanning tests
+    (report_nyquist_zeroing_impact.py, test_psf_fixture_regression.py) never
+    pick it up by accident.
+    """
+    base_ini_path = ini_dir / f"{case_name}.ini"
+    if not base_ini_path.exists():
+        raise FileNotFoundError(f"Missing INI file: {base_ini_path}")
+
+    config = ConfigParser()
+    config.optionxform = str
+    config.read(base_ini_path)
+    config.set("sources_science", "Wavelength", str(list(wavelengths_m)))
+
+    tmp_ini_dir = output_dir / "_tmp_ini"
+    tmp_ini_dir.mkdir(parents=True, exist_ok=True)
+    tmp_basename = f"{case_name}_multiwvl"
+    with open(tmp_ini_dir / f"{tmp_basename}.ini", "w") as f:
+        config.write(f)
+
+    simulation = baseSimulation(
+        path=str(tmp_ini_dir),
+        parametersFile=tmp_basename,
+        outputDir=str(output_dir),
+        outputFile=f"_tmp_{tmp_basename}",
+        doConvolve=False,
+        doPlot=False,
+        addSrAndFwhm=False,
+        verbose=False,
+        savePSDs=False,
+        exactMultiWavelengthPSD=True,
+    )
+    simulation.doOverallSimulation()
+
+    if not simulation.multiGridPSD:
+        raise RuntimeError(
+            f"{case_name}: exactMultiWavelengthPSD=True did not produce a "
+            f"per-wavelength PSD list (nWvl={simulation.nWvl}) -- need at "
+            f"least two distinct wavelengths."
+        )
+
+    n_pointings = simulation.pointings.shape[1]
+    n_wvl = len(wavelengths_m)
+
+    payload = {
+        "case_name": np.asarray(case_name),
+        "wavelength": np.asarray(simulation.wvl, dtype=np.float64),
+        "n_wvl": np.asarray(n_wvl),
+        "mask": _ensure_numpy_array(simulation.mask.sampling),
+        "nPixPsf": np.asarray(int(simulation.nPixPSF)),
+        "freq_range_per_wvl": np.asarray(simulation.freq_range_per_wvl, dtype=np.float64),
+        "dk_per_wvl": np.asarray(simulation.dk_per_wvl, dtype=np.float64),
+        "nPixPup_per_wvl": np.asarray(simulation.sx_per_wvl, dtype=np.int64),
+        "has_opd": np.asarray(simulation.opdMap is not None),
+        "opd_map": (
+            _ensure_numpy_array(simulation.opdMap)
+            if simulation.opdMap is not None
+            else np.asarray([], dtype=np.float64)
+        ),
+    }
+    for i in range(n_wvl):
+        payload[f"input_psds_{i}"] = _ensure_numpy_array(simulation.PSD[i][0:n_pointings])
+
+    fixture_path = output_dir / f"{case_name}_multiwvl.npz"
+    np.savez_compressed(fixture_path, **payload)
+    return fixture_path
+
+
 def select_psd_subset(psd_ho: np.ndarray, keep_single: bool) -> np.ndarray:
     if keep_single:
         return np.asarray(psd_ho[0:1])
@@ -108,6 +187,26 @@ def main() -> int:
         default=["MAVIS"],
         help="Cases for which only the first HO PSD is stored (default: MAVIS)",
     )
+    parser.add_argument(
+        "--multi-wavelength-case",
+        default=None,
+        help="If set, additionally export ONE exactMultiWavelengthPSD=True "
+             "fixture for this case (e.g. MAVIS), using --multi-wavelength-nm.",
+    )
+    parser.add_argument(
+        "--multi-wavelength-nm",
+        nargs="+",
+        type=float,
+        default=[450.0, 550.0, 850.0],
+        help="Wavelengths in nm for --multi-wavelength-case (default: 450 550 850)",
+    )
+    parser.add_argument(
+        "--multi-wavelength-out-dir",
+        default="../MASTSEL/tests/fixtures/psd_multiwavelength",
+        help="Output directory for the per-wavelength fixture (kept separate "
+             "from --out-dir so legacy single-grid fixture-scanning tests "
+             "never pick it up).",
+    )
 
     args = parser.parse_args()
 
@@ -137,6 +236,16 @@ def main() -> int:
     with metadata_path.open("w", encoding="utf-8") as f:
         json.dump({"fixtures": exported}, f, indent=2)
     print(f"Wrote manifest: {metadata_path}")
+
+    if args.multi_wavelength_case:
+        mw_out_dir = Path(args.multi_wavelength_out_dir).resolve()
+        mw_out_dir.mkdir(parents=True, exist_ok=True)
+        wavelengths_m = [nm * 1e-9 for nm in args.multi_wavelength_nm]
+        mw_fixture_path = export_multi_wavelength_case(
+            args.multi_wavelength_case, wavelengths_m, ini_dir, mw_out_dir
+        )
+        print(f"Exported multi-wavelength fixture: {mw_fixture_path}")
+
     return 0
 
 

--- a/tests/test_exact_multi_wavelength_psd.py
+++ b/tests/test_exact_multi_wavelength_psd.py
@@ -1,0 +1,106 @@
+import unittest
+import tempfile
+import os
+import numpy as np
+from configparser import ConfigParser
+
+from tiptop.baseSimulation import baseSimulation
+
+"""
+End-to-end regression tests for exactMultiWavelengthPSD=True: P3 computes one
+exact PSD grid per science wavelength (frequencyDomain.wvl_grids,
+psdPerWavelength=True) instead of one shared, approximate grid, and MASTSEL's
+psdSetToPsfSet decimates each wavelength's PSF exactly instead of resampling
+with a lossy affine_transform.
+
+Reuses the same lightweight ERIS config as
+TestTiptop.test_multiwavelength_eris_undersampled_sr_fwhm in test_all.py
+(8m telescope, wavelengths spanning an undersampled-to-oversampled range),
+since that is exactly the "lambda_min << lambda_max" regime this feature
+targets.
+"""
+
+
+def _make_config(wvl_list):
+    config = ConfigParser()
+    config.optionxform = str
+    config.read('tiptop/perfTest/ERIS.ini')
+    config.set('sources_science', 'Wavelength', str(wvl_list))
+    config.set('sensor_science', 'PixelScale', '14')
+    config.set('sensor_science', 'FieldOfView', '180')
+    config.set('telescope', 'Resolution', '64')
+    config.set('sensor_HO', 'NumberLenslets', '[16]')
+
+    fd, path = tempfile.mkstemp(suffix='.ini')
+    with os.fdopen(fd, 'w') as f:
+        config.write(f)
+    return path
+
+
+def _run(wvl_list, tag, exact_multi_wavelength_psd=False):
+    ini_path = _make_config(wvl_list)
+    try:
+        temp_dir = os.path.dirname(ini_path)
+        temp_basename = os.path.splitext(os.path.basename(ini_path))[0]
+        simulation = baseSimulation(
+            temp_dir, temp_basename, temp_dir, tag,
+            doConvolve=False, doPlot=False, verbose=False,
+            exactMultiWavelengthPSD=exact_multi_wavelength_psd)
+        simulation.doOverallSimulation()
+        simulation.computeMetrics()
+        return simulation
+    finally:
+        os.remove(ini_path)
+
+
+class TestExactMultiWavelengthPSD(unittest.TestCase):
+
+    def test_legacy_default_unaffected(self):
+        """exactMultiWavelengthPSD defaults to False: self.PSD stays a plain
+        array, multiGridPSD is False, matching pre-feature behaviour."""
+        sim = _run([0.865e-6, 2.21e-6], 'testLegacyDefault')
+        self.assertFalse(sim.multiGridPSD)
+        self.assertFalse(isinstance(sim.PSD, list))
+
+    def test_exact_multi_wavelength_runs_and_produces_valid_metrics(self):
+        sim = _run([0.865e-6, 2.21e-6], 'testExactRuns', exact_multi_wavelength_psd=True)
+        self.assertTrue(sim.multiGridPSD)
+        self.assertTrue(isinstance(sim.PSD, list))
+        self.assertEqual(len(sim.PSD), 2)
+
+        self.assertEqual(sim.cubeResultsArray.ndim, 4)
+        self.assertEqual(sim.cubeResultsArray.shape[0], 2)
+
+        for i in range(2):
+            sr_i = np.array(sim.sr[i]).ravel()
+            fwhm_i = np.array(sim.fwhm[i]).ravel()
+            self.assertTrue(np.all(np.isfinite(sr_i)))
+            self.assertTrue(np.all(sr_i > 0))
+            self.assertTrue(np.all(sr_i <= 1.0))
+            self.assertTrue(np.all(np.isfinite(fwhm_i)))
+
+    def test_each_wavelength_matches_standalone_single_wavelength_run(self):
+        """
+        The actual point of this feature: a wavelength's slice from a
+        multi-wavelength exactMultiWavelengthPSD=True run must be bit-for-bit
+        identical to a standalone run requesting only that one wavelength --
+        exercising the full P3 -> MASTSEL -> TIPTOP pipeline, not just the
+        PSD (as in P3's own tests) or synthetic inputs (as in MASTSEL's).
+        """
+        multi = _run([0.865e-6, 2.21e-6], 'testExactMulti', exact_multi_wavelength_psd=True)
+
+        for idx, wvl in enumerate([0.865e-6, 2.21e-6]):
+            with self.subTest(wvl_nm=wvl * 1e9):
+                mono = _run([wvl], f'testExactMono{int(wvl*1e9)}',
+                           exact_multi_wavelength_psd=True)
+                multi_slice = np.asarray(multi.cubeResultsArray[idx])
+                mono_slice = np.asarray(mono.cubeResultsArray)
+                self.assertEqual(multi_slice.shape, mono_slice.shape)
+                np.testing.assert_array_equal(
+                    multi_slice, mono_slice,
+                    err_msg=f"{wvl*1e9:.0f}nm slice differs from standalone run"
+                )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tiptop/baseSimulation.py
+++ b/tiptop/baseSimulation.py
@@ -32,7 +32,8 @@ class baseSimulation(AbstractSimulation):
 
     def __init__(self, path, parametersFile, outputDir, outputFile, doConvolve=True,
                  doPlot=False, addSrAndFwhm=True, verbose=False, getHoErrorBreakDown=False,
-                 savePSDs=False, ensquaredEnergy=False, eeRadiusInMas=50):
+                 savePSDs=False, ensquaredEnergy=False, eeRadiusInMas=50,
+                 exactMultiWavelengthPSD=False):
 
         # Superclass handles all configuration loading, validation, and standard properties
         super().__init__(path, parametersFile, outputDir, outputFile, doConvolve,
@@ -42,6 +43,16 @@ class baseSimulation(AbstractSimulation):
         # P3-specific state variables
         self.fao = None
         self.mLO = None
+
+        # When True and more than one [sources_science] Wavelength is
+        # requested, P3 computes one exact PSD grid per wavelength
+        # (psdPerWavelength=True) instead of one shared, approximate grid --
+        # see fourierModel/frequencyDomain in P3 for why this matters
+        # (equivalence with a standalone single-wavelength run) and its cost
+        # (roughly proportional to nWvl, since the reconstructor/controller
+        # are recomputed per wavelength too). Defaults to False: zero change
+        # in behaviour or cost for existing configurations.
+        self.exactMultiWavelengthPSD = exactMultiWavelengthPSD
 
     # ----------------------------------------------------------------------------
     # --- IMPLEMENTATION OF ABSTRACT METHODS ---
@@ -129,7 +140,8 @@ class baseSimulation(AbstractSimulation):
                                 display=False, getPSDatNGSpositions=self.LOisOn,
                                 computeFocalAnisoCov=False, TiltFilter=self.LOisOn,
                                 getErrorBreakDown=self.getHoErrorBreakDown, doComputations=False,
-                                psdExpansion=True, reduce_memory=True,
+                                psdExpansion=True, psdPerWavelength=self.exactMultiWavelengthPSD,
+                                reduce_memory=True,
                                 path_root=_TIPTOP_ROOT,
                                 config_dict=self.my_data_map)
 
@@ -140,9 +152,25 @@ class baseSimulation(AbstractSimulation):
 
         self.fao.initComputations()
 
-        # Cache geometry needed downstream
-        self.PSD = self.fao.PSD.transpose()
-        self.N = self.PSD[0].shape[0]
+        # self.fao.PSD is a list (one exact-grid array per science wavelength)
+        # only when exactMultiWavelengthPSD=True *and* more than one wavelength
+        # was requested -- see frequencyDomain.wvl_grids in P3. Otherwise (the
+        # default, and the only case before this feature existed) it stays a
+        # single (nOtf,nOtf,nSrc) array, exactly as today.
+        self.multiGridPSD = isinstance(self.fao.PSD, list)
+        if self.multiGridPSD:
+            self.PSD = [p.transpose() for p in self.fao.PSD]
+        else:
+            self.PSD = self.fao.PSD.transpose()
+
+        # N/PSDstep/freq_range/grid_diameter/dk/mask always describe P3's
+        # *shared* grid (self.fao.freq, unaffected by wvl_grids -- see
+        # frequencyDomain.py) and are what LO/Focus/open-loop/diffraction-
+        # limited PSFs keep using regardless of multiGridPSD, since those are
+        # single-wavelength constructs unrelated to the science wavelength
+        # list. Only the HO/science PSF path (_generate_final_PSF) additionally
+        # needs the per-wavelength freq_range/dk built below.
+        self.N = self.fao.freq.nOtf
         self.nPointings = self.pointings.shape[1]
         self.nPixPSF = int(self.fao.ao.cam.fovInPix)
         self.overSamp = getattr(self.fao.freq, 'kRef_float', int(self.fao.freq.kRef_))
@@ -153,6 +181,25 @@ class baseSimulation(AbstractSimulation):
         self.sx = int(2 * np.round(self.tel_radius * self.freq_range))
         self.dk = self.fao.freq.dk_
         self.wvlRef = self.fao.freq.wvlRef
+
+        if self.multiGridPSD:
+            # One freq_range/dk per science wavelength, matching self.PSD[i].
+            self.freq_range_per_wvl = [float(g.nOtf * g.PSDstep) for g in self.fao.freq.wvl_grids]
+            self.dk_per_wvl = [float(g.dk_) for g in self.fao.freq.wvl_grids]
+            # The pupil occupies a different fraction of each wavelength's own
+            # grid (nOtf_i varies with k_i while the physical pupil diameter
+            # does not), so nPixPup (self.sx) must vary per wavelength too --
+            # same formula as self.sx above, evaluated at each grid's own
+            # freq_range_i instead of the shared one.
+            self.sx_per_wvl = [int(2 * np.round(self.tel_radius * fr))
+                              for fr in self.freq_range_per_wvl]
+            # Index into self.wvl/self.PSD whose grid matches self.wvlRef
+            # (the minimum requested wavelength): used as "the" representative
+            # grid wherever a single-wavelength PSD slice is still needed
+            # (HO_res, NGS/Focus LO PSD) -- these quantities are physically
+            # wavelength-independent (WFE in nm), so any grid gives the same
+            # value up to the numerical-resolution differences between grids.
+            self.wvlRef_grid_idx = int(np.argmin(self.wvl))
 
         # Setup Mask
         self.mask = Field(self.wvlRef, self.N, self.grid_diameter)
@@ -204,11 +251,26 @@ class baseSimulation(AbstractSimulation):
 
                 lo_data['GF_res'] = float(np.sqrt(np.maximum(cpuArray(CtotFocus).ravel()[0], 0.0)))
 
-                # Apply Global Focus filtering to PSD
-                FocusFilter = self.fao.FocusFilter()
-                FocusFilter *= 1 / FocusFilter.sum()
-                for PSDho in self.PSD:
-                    PSDho += (lo_data['GF_res']**2) * FocusFilter
+                # Apply Global Focus filtering to PSD. FocusFilter() reads
+                # self.fao.freq.k2_, whose shape follows whichever grid
+                # self.fao.freq currently points to -- with a per-wavelength
+                # PSD list, self.PSD[i] has grid_i's own shape, so the filter
+                # must be rebuilt once per wavelength grid too (same swap
+                # pattern P3 itself uses internally for the PSD terms).
+                if self.multiGridPSD:
+                    saved_freq = self.fao.freq
+                    for i_wvl, grid_ctx in enumerate(self.fao.freq.wvl_grids):
+                        self.fao.freq = grid_ctx
+                        FocusFilter = self.fao.FocusFilter()
+                        FocusFilter *= 1 / FocusFilter.sum()
+                        for PSDho in self.PSD[i_wvl]:
+                            PSDho += (lo_data['GF_res']**2) * FocusFilter
+                    self.fao.freq = saved_freq
+                else:
+                    FocusFilter = self.fao.FocusFilter()
+                    FocusFilter *= 1 / FocusFilter.sum()
+                    for PSDho in self.PSD:
+                        PSDho += (lo_data['GF_res']**2) * FocusFilter
                 lo_data['GFinPSD'] = True
         else:
             # Asterism Specific Processing
@@ -258,24 +320,44 @@ class baseSimulation(AbstractSimulation):
         Convolves PSDs and standardizes the output in self.cubeResultsArray.
         """
         if astIndex is None or self.firstSimCall:
-            PSD_HO = arrayP3toMastsel(self.PSD[0:self.nPointings])
             mask = arrayP3toMastsel(self.fao.ao.tel.pupil)
 
             if self.verbose:
                 print('******** HO PSF')
 
-            psfLongExpPointingsArr = psdSetToPsfSet(PSD_HO, mask, self.wvl,
-                                                    nPixPup=self.sx, freq_range=self.freq_range,
-                                                    dk=self.dk, nPixPsf=self.nPixPSF,
-                                                    oversampling=self.overSamp,
-                                                    opdMap=self.opdMap)
+            if self.multiGridPSD:
+                # One list of per-direction PSDs per science wavelength --
+                # see mastsel.mavisPsf.psdSetToPsfSet's per-wavelength
+                # calling convention.
+                PSD_HO = [arrayP3toMastsel(self.PSD[i][0:self.nPointings])
+                          for i in range(self.nWvl)]
+                psfLongExpPointingsArr = psdSetToPsfSet(
+                    PSD_HO, mask, self.wvl, nPixPup=self.sx_per_wvl,
+                    freq_range=self.freq_range_per_wvl, dk=self.dk_per_wvl,
+                    nPixPsf=self.nPixPSF, opdMap=self.opdMap,
+                )
+                # HO_res (WFE in nm) is physically wavelength-independent;
+                # any grid gives the same value up to the numerical-resolution
+                # differences between grids, so the wvlRef-matching one is
+                # used as "the" representative value (consistent with wvlRef
+                # already being used this way elsewhere, e.g. computeMetrics).
+                self.HO_res = np.sqrt(np.sum(
+                    self.PSD[self.wvlRef_grid_idx][0:self.nPointings], axis=(1, 2)))
+            else:
+                PSD_HO = arrayP3toMastsel(self.PSD[0:self.nPointings])
+                psfLongExpPointingsArr = psdSetToPsfSet(PSD_HO, mask, self.wvl,
+                                                        nPixPup=self.sx, freq_range=self.freq_range,
+                                                        dk=self.dk, nPixPsf=self.nPixPSF,
+                                                        oversampling=self.overSamp,
+                                                        opdMap=self.opdMap)
 
-            # Safely compute HO residuals
-            self.HO_res = np.sqrt(np.sum(self.PSD[0:self.nPointings], axis=(1, 2)))
+                # Safely compute HO residuals
+                self.HO_res = np.sqrt(np.sum(self.PSD[0:self.nPointings], axis=(1, 2)))
 
             self.pointings_FWHM_mas = []
             for i in range(self.nWvl):
                 psfList = psfLongExpPointingsArr[i] if self.nWvl > 1 else psfLongExpPointingsArr
+                psd_i = PSD_HO[i] if self.multiGridPSD else PSD_HO
                 wvl_c = self.wvl[i] if self.nWvl > 1 else self.wvl[0]
                 samp_i = wvl_c * rad2mas / (self.psInMas * 2 * self.tel_radius)
                 rebin_i = max(1, int(np.ceil(2.0 / samp_i))) if samp_i < 2.0 else 1
@@ -286,7 +368,7 @@ class baseSimulation(AbstractSimulation):
                     fwhm = np.sqrt(fwhmX * fwhmY)
                     fwhmList.append(fwhm)
                     if self.verbose:
-                        s1 = cpuArray(PSD_HO[idx]).sum()
+                        s1 = cpuArray(psd_i[idx]).sum()
                         sr = np.exp(-s1 * (2*np.pi*1e-9/wvl_c)**2)
                         print(f'SR(@{int(wvl_c*1e9)}nm)        : {sr:.5f}')
                         print(f'FWHM(@{int(wvl_c*1e9)}nm) [mas]: {fwhm:.3f}')
@@ -459,9 +541,27 @@ class baseSimulation(AbstractSimulation):
             nPixPSFLO = self.nPixPSF
             lo_oversampling = self.overSamp
 
-        k = np.sqrt(self.fao.freq.k2_)
+        # HO_res/NGS/Focus PSDs are physically wavelength-independent (WFE in
+        # nm), but when multiGridPSD is on there is no shared-grid PSD array
+        # left (self.PSD is a per-science-wavelength list) -- so the NGS/Focus
+        # PSD slices, and the grid geometry (k2_/freq_range/dk/nPixPup) used
+        # to turn them into PSFs, must all come from the *same* single grid,
+        # here the one matching self.wvlRef (see _prepare_static_PSF_state).
+        if self.multiGridPSD:
+            ref_grid = self.fao.freq.wvl_grids[self.wvlRef_grid_idx]
+            k = np.sqrt(ref_grid.k2_)
+            psd_source = self.PSD[self.wvlRef_grid_idx]
+            ngs_freq_range = self.freq_range_per_wvl[self.wvlRef_grid_idx]
+            ngs_dk = self.dk_per_wvl[self.wvlRef_grid_idx]
+            ngs_nPixPup = self.sx_per_wvl[self.wvlRef_grid_idx]
+        else:
+            k = np.sqrt(self.fao.freq.k2_)
+            psd_source = self.PSD
+            ngs_freq_range = self.freq_range
+            ngs_dk = self.dk
+            ngs_nPixPup = self.sx
 
-        psdNGS_view = arrayP3toMastsel(self.PSD[-self.nNaturalGS_field:])
+        psdNGS_view = arrayP3toMastsel(psd_source[-self.nNaturalGS_field:])
 
         psdNGS = []
 
@@ -480,8 +580,8 @@ class baseSimulation(AbstractSimulation):
             print('******** LO PSF - NGS directions (1 sub-aperture)')
 
         psfLE_NGS = psdSetToPsfSet(psdNGS, maskLO, self.LO_wvl,
-                                   nPixPup=self.sx, freq_range=self.freq_range,
-                                   dk=self.dk, nPixPsf=nPixPSFLO, oversampling=lo_oversampling,
+                                   nPixPup=ngs_nPixPup, freq_range=ngs_freq_range,
+                                   dk=ngs_dk, nPixPsf=nPixPSFLO, oversampling=lo_oversampling,
                                    opdMap=self.opdMap)
 
         self.NGS_SR_field, self.NGS_FWHM_mas_field, self.NGS_EE_field = [], [], []
@@ -538,7 +638,7 @@ class baseSimulation(AbstractSimulation):
 
             if 'sensor_Focus' in self.my_data_map:
                 nSAfocus = self.my_data_map['sensor_Focus']['NumberLenslets']
-                psdFocus = arrayP3toMastsel(self.PSD[-self.nNaturalGS_field:])
+                psdFocus = arrayP3toMastsel(psd_source[-self.nNaturalGS_field:])
                 maskFocus = maskSA(nSAfocus, self.nNaturalGS_field, arrayP3toMastsel(self.fao.ao.tel.pupil))
 
                 for i in range(self.nNaturalGS_field):
@@ -548,8 +648,8 @@ class baseSimulation(AbstractSimulation):
                         psdFocus[i] = psdFocus[i] * pf
 
                 psfLE_Focus = psdSetToPsfSet(psdFocus, maskFocus, self.Focus_wvl,
-                                             nPixPup=self.sx, freq_range=self.freq_range,
-                                             dk=self.dk, nPixPsf=nPixPSFFocus,
+                                             nPixPup=ngs_nPixPup, freq_range=ngs_freq_range,
+                                             dk=ngs_dk, nPixPsf=nPixPSFFocus,
                                              oversampling=focus_oversampling,
                                              opdMap=self.opdMap)
 


### PR DESCRIPTION
## TIPTOP — PR title: Add exactMultiWavelengthPSD option (uses P3 psdPerWavelength + MASTSEL per-wavelength PSF generation)

**Why**: closes the loop for users who need multi-wavelength PSFs that are numerically identical to single-wavelength runs — e.g. wide-band instruments where the shared-grid approximation (current default) causes visible differences between a wavelength simulated alone vs. as part of a multi-wavelength run.

**What**: new `exactMultiWavelengthPSD=False` (default) parameter on `baseSimulation`. When enabled, P3 is asked for one exact PSD grid per science wavelength and the whole HO PSF path (mask/pupil sizing, LO/Focus NGS PSDs, global focus filtering) is adapted to consume it.

**Note**: this is not a faster or "better by default" mode — it's an exactness option, not a numerical optimization, and cost scales roughly with the number of wavelengths (each grid recomputes the reconstructor/controller). It should not be compared on performance to the default path. The default (shared-grid, approximate) path stays exactly as it is today and remains the default — this is purely an additional choice, nothing is being replaced.

**Compatibility**: default behaviour unchanged; verified against the existing multi-wavelength test suite and a new end-to-end equivalence test (bit-exact match between a multi-wavelength slice and a standalone run, real ERIS config).

**Dependencies**: requires the P3 (`psdPerWavelength`) and MASTSEL (per-wavelength `psdSetToPsfSet`) PRs merged **and released** first — update `requirements`/pinned versions to the new P3 and MASTSEL releases before merging this one. This must be the last of the three merges.
